### PR TITLE
Legacy mongo support

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -7,7 +7,8 @@
       "user": "",
       "password": "",
       "authenticationDatabase": "",
-      "ssl": false
+      "ssl": false,
+      "compression": "--gzip"
     },
     "documentStorage": {
       "storageType": "local",
@@ -26,7 +27,8 @@
   "local": {
     "database": "ll_migrate_local",
     "sourceDumpLocation": "./dumps/source",
-    "targetDumpLocation": "./dumps/target"
+    "targetDumpLocation": "./dumps/target",
+    "compression": "--gzip"
   },
   "target": {
     "orgId": "",
@@ -37,7 +39,8 @@
       "password": "",
       "authenticationDatabase": "",
       "ssl": false,
-      "quiet": true
+      "quiet": true,
+      "compression": "--gzip"
     },
     "documentStorage": {
       "storageType": "local",

--- a/config/example.json
+++ b/config/example.json
@@ -8,7 +8,7 @@
       "password": "",
       "authenticationDatabase": "",
       "ssl": false,
-      "compression": "--gzip"
+      "compression": true
     },
     "documentStorage": {
       "storageType": "local",
@@ -28,7 +28,7 @@
     "database": "ll_migrate_local",
     "sourceDumpLocation": "./dumps/source",
     "targetDumpLocation": "./dumps/target",
-    "compression": "--gzip"
+    "compression": true
   },
   "target": {
     "orgId": "",
@@ -40,7 +40,7 @@
       "authenticationDatabase": "",
       "ssl": false,
       "quiet": true,
-      "compression": "--gzip"
+      "compression": true
     },
     "documentStorage": {
       "storageType": "local",

--- a/src/dumpLocalData.js
+++ b/src/dumpLocalData.js
@@ -4,5 +4,5 @@ const logStep = require('./logStep');
 
 module.exports = () => {
   logStep('Dumping local data', true);
-  return exec(`mongodump --db ${config.local.database} --gzip --out ${config.local.targetDumpLocation}`);
+  return exec(`mongodump --db ${config.local.database} ${config.local.compression} --out ${config.local.targetDumpLocation}`);
 };

--- a/src/dumpLocalData.js
+++ b/src/dumpLocalData.js
@@ -1,8 +1,12 @@
 const exec = require('./exec');
 const config = require('./config');
 const logStep = require('./logStep');
+const createCLIFlag = require('./createCLIFlag');
+
+const localDb = config.local.database;
+const compression = createCLIFlag('--gzip', localDb.compression);
 
 module.exports = () => {
   logStep('Dumping local data', true);
-  return exec(`mongodump --db ${config.local.database} ${config.local.compression} --out ${config.local.targetDumpLocation}`);
+  return exec(`mongodump --db ${localDb.database} ${compression} --out ${localDb.targetDumpLocation}`);
 };

--- a/src/dumpSourceData.js
+++ b/src/dumpSourceData.js
@@ -13,7 +13,7 @@ const dumpCollection = (collection, query = '{}') => {
   const authDb = createCLIOption('--authenticationDatabase', sourceDb.authenticationDatabase);
   const ssl = createCLIFlag('--ssl', sourceDb.ssl);
   return exec(
-    `mongodump ${ssl} --host ${sourceDb.hosts} --db ${sourceDb.name} ${user} ${password} ${authDb} --collection ${collection} --query '${query}' --gzip --out ${config.local.sourceDumpLocation}`
+    `mongodump ${ssl} --host ${sourceDb.hosts} --db ${sourceDb.name} ${user} ${password} ${authDb} --collection ${collection} --query '${query}' ${sourceDb.commpression} --out ${config.local.sourceDumpLocation}`
   ).catch((err) => {
     console.error(`ERROR DUMPING SOURCE ${collection}. This collection may not exist`, err);
   });

--- a/src/dumpSourceData.js
+++ b/src/dumpSourceData.js
@@ -12,8 +12,9 @@ const dumpCollection = (collection, query = '{}') => {
   const password = createCLIOption('-p', sourceDb.password);
   const authDb = createCLIOption('--authenticationDatabase', sourceDb.authenticationDatabase);
   const ssl = createCLIFlag('--ssl', sourceDb.ssl);
+  const compression = createCLIFlag('--gzip', sourceDB.compression);
   return exec(
-    `mongodump ${ssl} --host ${sourceDb.hosts} --db ${sourceDb.name} ${user} ${password} ${authDb} --collection ${collection} --query '${query}' ${sourceDb.commpression} --out ${config.local.sourceDumpLocation}`
+    `mongodump ${ssl} --host ${sourceDb.hosts} --db ${sourceDb.name} ${user} ${password} ${authDb} --collection ${collection} --query '${query}' ${compression} --out ${config.local.sourceDumpLocation}`
   ).catch((err) => {
     console.error(`ERROR DUMPING SOURCE ${collection}. This collection may not exist`, err);
   });

--- a/src/restoreLocalData.js
+++ b/src/restoreLocalData.js
@@ -6,5 +6,5 @@ const sourceDb = config.source.database;
 
 module.exports = () => {
   logStep('Restoring local data', true);
-  return exec(`mongorestore --db ${config.local.database} --gzip --noIndexRestore ${config.local.sourceDumpLocation}/${sourceDb.name}`);
+  return exec(`mongorestore --db ${config.local.database} ${config.local.compression} --noIndexRestore ${config.local.sourceDumpLocation}/${sourceDb.name}`);
 };

--- a/src/restoreLocalData.js
+++ b/src/restoreLocalData.js
@@ -1,10 +1,12 @@
 const exec = require('./exec');
 const config = require('./config');
 const logStep = require('./logStep');
+const createCLIFlag = require('./createCLIFlag');
 
 const sourceDb = config.source.database;
+const compression = createCLIFlag('--gzip', sourceDb.compression);
 
 module.exports = () => {
   logStep('Restoring local data', true);
-  return exec(`mongorestore --db ${config.local.database} ${config.local.compression} --noIndexRestore ${config.local.sourceDumpLocation}/${sourceDb.name}`);
+  return exec(`mongorestore --db ${config.local.database} ${compression} --noIndexRestore ${config.local.sourceDumpLocation}/${sourceDb.name}`);
 };

--- a/src/restoreTargetData.js
+++ b/src/restoreTargetData.js
@@ -13,5 +13,6 @@ module.exports = () => {
   const authDb = createCLIOption('--authenticationDatabase', targetDb.authenticationDatabase);
   const ssl = createCLIFlag('--ssl', targetDb.ssl);
   const quiet = createCLIFlag('--quiet', targetDb.quiet);
-  return exec(`mongorestore ${ssl} --db=${targetDb.name} --host ${targetDb.hosts} ${authDb} ${user} ${password} ${quiet} --noIndexRestore ${targetDb.compression} ${config.local.targetDumpLocation}/${config.local.database}`);
+  const compression = createCLIFlag('--gzip', targetDb.compression);
+  return exec(`mongorestore ${ssl} --db=${targetDb.name} --host ${targetDb.hosts} ${authDb} ${user} ${password} ${quiet} --noIndexRestore ${compression} ${config.local.targetDumpLocation}/${config.local.database}`);
 };

--- a/src/restoreTargetData.js
+++ b/src/restoreTargetData.js
@@ -13,5 +13,5 @@ module.exports = () => {
   const authDb = createCLIOption('--authenticationDatabase', targetDb.authenticationDatabase);
   const ssl = createCLIFlag('--ssl', targetDb.ssl);
   const quiet = createCLIFlag('--quiet', targetDb.quiet);
-  return exec(`mongorestore ${ssl} --db=${targetDb.name} --host ${targetDb.hosts} ${authDb} ${user} ${password} ${quiet} --noIndexRestore --gzip ${config.local.targetDumpLocation}/${config.local.database}`);
+  return exec(`mongorestore ${ssl} --db=${targetDb.name} --host ${targetDb.hosts} ${authDb} ${user} ${password} ${quiet} --noIndexRestore ${targetDb.compression} ${config.local.targetDumpLocation}/${config.local.database}`);
 };


### PR DESCRIPTION
The --gzip flag is only available in MongoDB v3.2+. Since LLv1 had lower MongoDB version requirements, there should be an option to remove the --gzip flag. 

I've added a compression flag option to the config file and updated the various places where it can be called. I tested this on a LLv1 instance that I have and it worked correctly.